### PR TITLE
Add missing header for offsetof()

### DIFF
--- a/src/grf.c
+++ b/src/grf.c
@@ -2,6 +2,7 @@
 #include "compression.h"
 #include "texture.h"
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
In Linux I need to include `stddef.h` for `offsetof()` to be defined.