### PR TITLE
Use strdup() when not using MSVC

### DIFF
--- a/src/texconv.c
+++ b/src/texconv.c
@@ -9,6 +9,7 @@
 #ifndef _MSC_VER
 #	define min(a,b) ((a)<(b)?(a):(b))
 #	define max(a,b) ((a)>(b)?(a):(b))
+#	define _strdup(x) strdup(x)
 #endif
 
 //optimize for speed rather than size


### PR DESCRIPTION
_strdup() isn't a standard C function.